### PR TITLE
correct Whitenoise to WhiteNoise

### DIFF
--- a/pydub-stubs/generators.pyi
+++ b/pydub-stubs/generators.pyi
@@ -37,5 +37,5 @@ class Sawtooth(SignalGenerator):
 class Triangle(Sawtooth):
     def __init__(self, freq: float, *, sample_rate: int = ..., bit_depth: Literal[8, 16, 32] = ...) -> None: ...
 
-class Whitenoise(SignalGenerator):
+class WhiteNoise(SignalGenerator):
     def generate(self) -> Iterator[float]: ...


### PR DESCRIPTION
see https://github.com/jiaaro/pydub/blob/master/pydub/generators.py#L139

Otherwise, I get the following error when running mypy:

```py
test.py:1: error: Module "pydub.generators" has no attribute "WhiteNoise"; maybe "Whitenoise"?  [attr-defined]
```
on the file containing just
```py
from pydub.generators import WhiteNoise
```
